### PR TITLE
feat: add streamlit scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ dist/
 *.log
 
 chroma_data/
+data/
+logs/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# RAG Learning Project
+
+This repository contains a Streamlit based demo for a Retrieval-Augmented Generation (RAG) system. It implements
+basic scaffolding for login, file uploads and a placeholder chat interface.
+
+## Features
+- **Login system**: ten built-in demo accounts defined in `config/accounts.json`.
+- **Knowledge base page**: upload files to per-user folders under `data/<user>/uploads`.
+- **Chat page**: placeholder interface for asking questions; currently returns a static message.
+
+The project is structured so that further development can add document parsing, chunking, embedding with Qwen
+`text-embedding-v4`, storage in Chroma and retrieval augmented generation following the detailed specification.
+
+## Running
+Install dependencies and start the Streamlit app:
+
+```bash
+pip install -r requirements.txt
+streamlit run app/main.py
+```
+
+## Repository layout
+```
+app/            # Streamlit application entry point
+config/         # demo account configuration
+requirements.txt
+README.md
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,87 @@
+import json
+import os
+from pathlib import Path
+
+import streamlit as st
+
+ACCOUNTS_FILE = Path(__file__).resolve().parent.parent / "config" / "accounts.json"
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+
+def load_accounts():
+    if ACCOUNTS_FILE.exists():
+        with open(ACCOUNTS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return {u["username"]: u["password"] for u in data.get("users", [])}
+    return {}
+
+
+def ensure_user_dirs(user: str):
+    (DATA_DIR / user / "uploads").mkdir(parents=True, exist_ok=True)
+
+
+def login_view():
+    st.markdown(
+        "<div style='background-color:#FDE68A;padding:8px;border-radius:4px;'>仅供演示，不代表生产安全实践</div>",
+        unsafe_allow_html=True,
+    )
+    st.subheader("登录")
+    username = st.text_input("账号")
+    password = st.text_input("密码", type="password")
+    if st.button("登录"):
+        accounts = load_accounts()
+        if accounts.get(username) == password:
+            st.session_state["authenticated"] = True
+            st.session_state["user"] = username
+            ensure_user_dirs(username)
+            st.experimental_rerun()
+        else:
+            st.error("账号或密码错误")
+
+
+def chat_page():
+    st.subheader("知识库智能问答")
+    user = st.session_state.get("user")
+    st.write(f"当前用户：{user}")
+    query = st.text_input("请输入您的问题")
+    if st.button("发送"):
+        if query.strip():
+            st.info("暂未接入向量检索，示例回答：未上传文档")
+
+
+def kb_page():
+    st.subheader("个人知识库")
+    user = st.session_state.get("user")
+    uploads_dir = DATA_DIR / user / "uploads"
+    uploaded = st.file_uploader("上传文件", accept_multiple_files=True)
+    if uploaded:
+        for file in uploaded:
+            dest = uploads_dir / file.name
+            with open(dest, "wb") as f:
+                f.write(file.getvalue())
+        st.success("上传成功")
+    if uploads_dir.exists():
+        st.write("当前已有文件：")
+        for p in uploads_dir.iterdir():
+            st.write("- ", p.name)
+
+
+def main():
+    st.set_page_config(page_title="知识库智能问答", layout="wide")
+    if "authenticated" not in st.session_state:
+        st.session_state["authenticated"] = False
+    if not st.session_state["authenticated"]:
+        login_view()
+        return
+
+    st.sidebar.title("导航")
+    page = st.sidebar.radio("", ("对话", "知识库"))
+    st.sidebar.button("退出登录", on_click=lambda: st.session_state.update({"authenticated": False}))
+    if page == "对话":
+        chat_page()
+    else:
+        kb_page()
+
+
+if __name__ == "__main__":
+    main()

--- a/config/accounts.json
+++ b/config/accounts.json
@@ -1,0 +1,14 @@
+{
+  "users": [
+    {"username": "user01", "password": "pass01"},
+    {"username": "user02", "password": "pass02"},
+    {"username": "user03", "password": "pass03"},
+    {"username": "user04", "password": "pass04"},
+    {"username": "user05", "password": "pass05"},
+    {"username": "user06", "password": "pass06"},
+    {"username": "user07", "password": "pass07"},
+    {"username": "user08", "password": "pass08"},
+    {"username": "user09", "password": "pass09"},
+    {"username": "user10", "password": "pass10"}
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+streamlit>=1.32
+chromadb>=0.4
+pymupdf
+pdf2image
+Pillow
+opencv-python
+rapidocr-onnxruntime
+python-docx
+docx2pdf
+camelot-py[cv]
+openpyxl
+dashscope


### PR DESCRIPTION
## Summary
- add Streamlit-based scaffold with demo login accounts
- enable per-user file uploads and placeholder chat interface
- provide initial project documentation and dependencies

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab10eabd8c832db3cc86112994692d