### PR TITLE
Clarify DashScope setup and add OpenAI dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,17 @@ The project is structured so that further development can add document parsing, 
 `text-embedding-v4`, storage in Chroma and retrieval augmented generation following the detailed specification.
 
 ## Running
-Install dependencies and start the Streamlit app:
+Install dependencies (including `openai>=1.0`) and start the Streamlit app. Before
+launching the app, set `DASHSCOPE_API_KEY` in the environment so the client can
+authenticate against DashScope. Optionally set `DASHSCOPE_BASE_URL` to override
+the default endpoint.
 
 ```bash
 pip install -r requirements.txt
+
+export DASHSCOPE_API_KEY="<your_api_key>"
+# export DASHSCOPE_BASE_URL="https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+
 streamlit run app/main.py
 ```
 

--- a/app/rag.py
+++ b/app/rag.py
@@ -17,14 +17,19 @@ DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 # ---------- OpenAI/Qwen Client ----------
 def get_client() -> "OpenAI":
     """Return an OpenAI-compatible client for Qwen models."""
-    if OpenAI is None:
-        raise RuntimeError("openai package not available")
+    if OpenAI is None:  # pragma: no cover - dependency injection
+        raise RuntimeError(
+            "The 'openai' package is required. Install dependencies with `pip install -r requirements.txt`."
+        )
     api_key = os.getenv("DASHSCOPE_API_KEY")
     base_url = os.getenv(
         "DASHSCOPE_BASE_URL", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
     )
     if not api_key:
-        raise RuntimeError("DASHSCOPE_API_KEY not set")
+        raise RuntimeError(
+            "DASHSCOPE_API_KEY environment variable not set. "
+            "Export it before running the app, e.g. `export DASHSCOPE_API_KEY=...`."
+        )
     return OpenAI(api_key=api_key, base_url=base_url)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ python-docx
 docx2pdf
 camelot-py[cv]
 openpyxl
+openai>=1.0
 dashscope


### PR DESCRIPTION
## Summary
- require `openai>=1.0`
- document and validate DashScope API key environment variables
- provide clearer error messages for missing OpenAI package or API key

## Testing
- `pip install 'openai>=1.0'` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile app/rag.py`
- `python - <<'PY'
import os
from app.rag import get_client
try:
    client = get_client()
    print('client', client)
except Exception as e:
    print('Error:', e)
PY`
- `python - <<'PY'
import os
from app import rag
class Dummy:
    def __init__(self, **kwargs):
        pass
rag.OpenAI = Dummy
try:
    rag.get_client()
except Exception as e:
    print('Error:', e)
PY`
- `python - <<'PY'
import os
from pathlib import Path
from app.rag import index_file, chat_with_docs
os.environ['DASHSCOPE_API_KEY'] = 'test'
try:
    doc_id = index_file('user1', Path('README.md'))
    print('Indexed doc', doc_id)
    answer = chat_with_docs('user1', 'What is this project?')
    print('Answer', answer)
except Exception as e:
    print('Error:', type(e).__name__, e)
PY` *(hangs due to bug in chunk_text; interrupted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68ab29dc6bb8832d838cffb8c875f265